### PR TITLE
RentACar now uses InfoStruct

### DIFF
--- a/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/InfoStruct.java
+++ b/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/InfoStruct.java
@@ -1,0 +1,35 @@
+package pt.ulisboa.tecnico.softeng.car.domain;
+
+public class InfoStruct {
+  private String name;
+  private String nif;
+  private String iban;
+
+  public InfoStruct() {
+
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getNif() {
+    return this.nif;
+  }
+
+  public String getIban() {
+    return this.iban;
+  }
+
+  public void setName(String arg) {
+    this.name = arg;
+  }
+
+  public void setNif(String arg) {
+    this.nif = arg;
+  }
+
+  public void setIban(String arg) {
+    this.iban = arg;
+  } 
+}

--- a/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/InfoStruct.java
+++ b/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/InfoStruct.java
@@ -1,11 +1,47 @@
 package pt.ulisboa.tecnico.softeng.car.domain;
 
+import pt.ulisboa.tecnico.softeng.car.exception.CarException;
+
 public class InfoStruct {
+
+  public static class Builder {
+    private String name;
+    private String nif;
+    private String iban;
+
+    public Builder() {
+
+    }
+    public Builder setName(String arg) {
+      this.name = arg;
+      return this;
+    }
+
+    public Builder setNif(String arg) {
+      this.nif = arg;
+      return this;
+    }
+
+    public Builder setIban(String arg) {
+      this.iban = arg;
+      return this;
+    }
+
+    public InfoStruct build() {
+      InfoStruct info = new InfoStruct();
+      info.setName(this.name);
+      info.setNif(this.nif);
+      info.setIban(this.iban);
+      return info;
+    }
+
+  }
+
   private String name;
   private String nif;
   private String iban;
 
-  public InfoStruct() {
+  private InfoStruct() {
 
   }
 

--- a/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/RentACar.java
+++ b/car/src/main/java/pt/ulisboa/tecnico/softeng/car/domain/RentACar.java
@@ -10,13 +10,13 @@ import java.util.Set;
 public class RentACar extends RentACar_Base {
     public final static int SCALE = 1000;
 
-    public RentACar(final String name, final String nif, final String iban, final Processor processor) {
-        checkArguments(name, nif, iban);
+    public RentACar(final InfoStruct info, final Processor processor) {
+        checkArguments(info.getName(), info.getNif(), info.getIban());
 
-        setCode(nif + getCounter());
-        setName(name);
-        setNif(nif);
-        setIban(iban);
+        setCode(info.getNif() + getCounter());
+        setName(info.getName());
+        setNif(info.getNif());
+        setIban(info.getIban());
         setProcessor(processor);
 
         FenixFramework.getDomainRoot().addRentACar(this);

--- a/car/src/main/java/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterface.java
+++ b/car/src/main/java/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterface.java
@@ -29,10 +29,11 @@ public class RentACarInterface {
     @Atomic(mode = Atomic.TxMode.WRITE)
     public void createRentACar(final RentACarData rentACarData) {
         final Processor processor = new Processor(new BankInterface(), new TaxInterface());
-        InfoStruct info = new InfoStruct();
-        info.setName(rentACarData.getName());
-        info.setNif(rentACarData.getNif());
-        info.setIban(rentACarData.getIban());
+        InfoStruct info = new InfoStruct.Builder()
+          .setName(rentACarData.getName())
+          .setNif(rentACarData.getNif())
+          .setIban(rentACarData.getIban())
+          .build();
         new RentACar(info, processor);
     }
 

--- a/car/src/main/java/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterface.java
+++ b/car/src/main/java/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterface.java
@@ -29,7 +29,11 @@ public class RentACarInterface {
     @Atomic(mode = Atomic.TxMode.WRITE)
     public void createRentACar(final RentACarData rentACarData) {
         final Processor processor = new Processor(new BankInterface(), new TaxInterface());
-        new RentACar(rentACarData.getName(), rentACarData.getNif(), rentACarData.getIban(), processor);
+        InfoStruct info = new InfoStruct();
+        info.setName(rentACarData.getName());
+        info.setNif(rentACarData.getNif());
+        info.setIban(rentACarData.getIban());
+        new RentACar(info, processor);
     }
 
     @Atomic(mode = Atomic.TxMode.READ)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/CarPersistenceSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/CarPersistenceSpockTest.groovy
@@ -25,7 +25,11 @@ class CarPersistenceSpockTest extends SpockPersistenceTestAbstractClass {
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        def rentACar = new RentACar(NAME1, NIF, IBAN, processor)
+        def info = new InfoStruct()
+        info.setName(NAME1)
+        info.setNif(NIF)
+        info.setIban(IBAN)
+        def rentACar = new RentACar(info, processor)
         def car = new Car(PLATE_CAR1, 10, 10, rentACar)
         def motorcycle = new Motorcycle(PLATE_CAR2, 20, 5, rentACar)
         car.rent(DRIVING_LICENSE, date1, date2, NIF, IBAN_BUYER, ADVENTURE_ID)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/CarPersistenceSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/CarPersistenceSpockTest.groovy
@@ -25,10 +25,7 @@ class CarPersistenceSpockTest extends SpockPersistenceTestAbstractClass {
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        def info = new InfoStruct()
-        info.setName(NAME1)
-        info.setNif(NIF)
-        info.setIban(IBAN)
+        def info = new InfoStruct.Builder().setName(NAME1).setNif(NIF).setIban(IBAN).build()
         def rentACar = new RentACar(info, processor)
         def car = new Car(PLATE_CAR1, 10, 10, rentACar)
         def motorcycle = new Motorcycle(PLATE_CAR2, 20, 5, rentACar)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/ProcessorSubmitRentingMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/ProcessorSubmitRentingMethodSpockTest.groovy
@@ -38,7 +38,11 @@ class ProcessorSubmitRentingMethodSpockTest extends SpockRollbackTestAbstractCla
         taxInterface = Mock(TaxInterface)
         def processor = new Processor(bankInterface, taxInterface)
 
-        rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+        def info = new InfoStruct()
+        info.setName(RENT_A_CAR_NAME)
+        info.setNif(NIF)
+        info.setIban(IBAN)
+        rentACar = new RentACar(info, processor)
         car = new Car(PLATE_CAR, 10, 10, rentACar)
         rentingOne = new Renting(DRIVING_LICENSE, date0, date1, car, NIF_CUSTOMER, IBAN_CUSTOMER)
         rentingTwo = new Renting(DRIVING_LICENSE, date2, date3, car, NIF_CUSTOMER, IBAN_CUSTOMER)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/ProcessorSubmitRentingMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/ProcessorSubmitRentingMethodSpockTest.groovy
@@ -38,10 +38,7 @@ class ProcessorSubmitRentingMethodSpockTest extends SpockRollbackTestAbstractCla
         taxInterface = Mock(TaxInterface)
         def processor = new Processor(bankInterface, taxInterface)
 
-        def info = new InfoStruct()
-        info.setName(RENT_A_CAR_NAME)
-        info.setNif(NIF)
-        info.setIban(IBAN)
+        def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
         rentACar = new RentACar(info, processor)
         car = new Car(PLATE_CAR, 10, 10, rentACar)
         rentingOne = new Renting(DRIVING_LICENSE, date0, date1, car, NIF_CUSTOMER, IBAN_CUSTOMER)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentACarConstructorSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentACarConstructorSpockTest.groovy
@@ -24,10 +24,7 @@ class RentACarConstructorSpockTest extends SpockRollbackTestAbstractClass {
 
 	def 'success'() {
 		when: 'creating a new RentACar'
-    def info = new InfoStruct()
-    info.setName(NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(NAME).setNif(NIF).setIban(IBAN).build()
     def rentACar = new RentACar(info, processor)
 
 		then: 'should succeed'
@@ -38,10 +35,7 @@ class RentACarConstructorSpockTest extends SpockRollbackTestAbstractClass {
 	@Unroll('RentACar: #name')
 	def 'exceptions'() {
 		when: 'creating a RentACar with invalid arguments'
-    def info = new InfoStruct()
-    info.setName(name)
-    info.setNif(nif)
-    info.setIban(iban)
+    def info = new InfoStruct.Builder().setName(name).setNif(nif).setIban(iban).build()
     new RentACar(info, processor)
 		new RentACar(name, nif, iban, processor)
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentACarConstructorSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentACarConstructorSpockTest.groovy
@@ -24,7 +24,11 @@ class RentACarConstructorSpockTest extends SpockRollbackTestAbstractClass {
 
 	def 'success'() {
 		when: 'creating a new RentACar'
-		def rentACar = new RentACar(NAME, NIF, IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    def rentACar = new RentACar(info, processor)
 
 		then: 'should succeed'
 		rentACar.getName() == NAME
@@ -34,6 +38,11 @@ class RentACarConstructorSpockTest extends SpockRollbackTestAbstractClass {
 	@Unroll('RentACar: #name')
 	def 'exceptions'() {
 		when: 'creating a RentACar with invalid arguments'
+    def info = new InfoStruct()
+    info.setName(name)
+    info.setNif(nif)
+    info.setIban(iban)
+    new RentACar(info, processor)
 		new RentACar(name, nif, iban, processor)
 
 		then: 'throws an exception'

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingCheckoutMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingCheckoutMethodSpockTest.groovy
@@ -25,10 +25,7 @@ class RentingCheckoutMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(NAME1)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(NAME1).setNif(NIF).setIban(IBAN).build()
     def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR1,10,10,rentACar)
 	}

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingCheckoutMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingCheckoutMethodSpockTest.groovy
@@ -25,7 +25,11 @@ class RentingCheckoutMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		def rentACar = new RentACar(NAME1,NIF,IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(NAME1)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR1,10,10,rentACar)
 	}
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConflictMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConflictMethodSpockTest.groovy
@@ -29,10 +29,7 @@ class RentingConflictMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR,10,10,rentACar)
 	}

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConflictMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConflictMethodSpockTest.groovy
@@ -29,7 +29,11 @@ class RentingConflictMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		def rentACar = new RentACar(RENT_A_CAR_NAME,NIF,IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR,10,10,rentACar)
 	}
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConstructorSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConstructorSpockTest.groovy
@@ -26,7 +26,11 @@ class RentingConstructorSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		def rentACar = new RentACar(RENT_A_CAR_NAME, NIF,IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR, 10, 10, rentACar)
 	}
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConstructorSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/RentingConstructorSpockTest.groovy
@@ -26,10 +26,7 @@ class RentingConstructorSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR, 10, 10, rentACar)
 	}

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleConstructorMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleConstructorMethodSpockTest.groovy
@@ -22,7 +22,11 @@ class VehicleConstructorMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    rentACar = new RentACar(info, processor)
 	}
 
 	def 'success'() {
@@ -82,8 +86,11 @@ class VehicleConstructorMethodSpockTest extends SpockRollbackTestAbstractClass {
 		given: 'create a car in rent-a-car'
 		new Car(PLATE_CAR, 0, 10, rentACar)
 		and: 'another rent a car'
-		def rentACar2 = new RentACar(RENT_A_CAR_NAME + '2', NIF + "1", IBAN,
-				new Processor(new BankInterface(), new TaxInterface()))
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME + "2")
+    info.setNif(NIF + "1")
+    info.setIban(IBAN)
+		def rentACar2 = new RentACar(info, new Processor(new BankInterface(), new TaxInterface()))
 
 		when: 'creating a car in the other rent-a-car with the same plate'
 		new Car(PLATE_CAR, 2, 10, rentACar2)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleConstructorMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleConstructorMethodSpockTest.groovy
@@ -22,10 +22,7 @@ class VehicleConstructorMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     rentACar = new RentACar(info, processor)
 	}
 
@@ -86,10 +83,7 @@ class VehicleConstructorMethodSpockTest extends SpockRollbackTestAbstractClass {
 		given: 'create a car in rent-a-car'
 		new Car(PLATE_CAR, 0, 10, rentACar)
 		and: 'another rent a car'
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME + "2")
-    info.setNif(NIF + "1")
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME + "2").setNif(NIF + "1").setIban(IBAN).build()
 		def rentACar2 = new RentACar(info, new Processor(new BankInterface(), new TaxInterface()))
 
 		when: 'creating a car in the other rent-a-car with the same plate'

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleIsFreeMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleIsFreeMethodSpockTest.groovy
@@ -29,10 +29,7 @@ class VehicleIsFreeMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR,10,10,rentACar)
 	}

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleIsFreeMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleIsFreeMethodSpockTest.groovy
@@ -29,7 +29,11 @@ class VehicleIsFreeMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		def rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    def rentACar = new RentACar(info, processor)
 		car = new Car(PLATE_CAR,10,10,rentACar)
 	}
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleRentMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleRentMethodSpockTest.groovy
@@ -28,7 +28,11 @@ class VehicleRentMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    rentACar = new RentACar(info, processor)
 	}
 
 	def 'double rent'() {

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleRentMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/domain/VehicleRentMethodSpockTest.groovy
@@ -28,10 +28,7 @@ class VehicleRentMethodSpockTest extends SpockRollbackTestAbstractClass {
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     rentACar = new RentACar(info, processor)
 	}
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceCancelRentingMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceCancelRentingMethodSpockTest.groovy
@@ -3,10 +3,7 @@ package pt.ulisboa.tecnico.softeng.car.services.local
 import org.joda.time.LocalDate
 import spock.lang.Unroll
 
-import pt.ulisboa.tecnico.softeng.car.domain.Car
-import pt.ulisboa.tecnico.softeng.car.domain.Processor
-import pt.ulisboa.tecnico.softeng.car.domain.RentACar
-import pt.ulisboa.tecnico.softeng.car.domain.SpockRollbackTestAbstractClass
+import pt.ulisboa.tecnico.softeng.car.domain.*
 import pt.ulisboa.tecnico.softeng.car.exception.CarException
 import pt.ulisboa.tecnico.softeng.car.services.remote.BankInterface
 import pt.ulisboa.tecnico.softeng.car.services.remote.TaxInterface
@@ -34,7 +31,11 @@ class RentACarInterfaceCancelRentingMethodSpockTest extends SpockRollbackTestAbs
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(RENT_A_CAR_NAME)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    rentACar = new RentACar(info, processor)
 
 		car = new Car(PLATE_CAR,10,10,rentACar)
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceCancelRentingMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceCancelRentingMethodSpockTest.groovy
@@ -31,10 +31,7 @@ class RentACarInterfaceCancelRentingMethodSpockTest extends SpockRollbackTestAbs
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(RENT_A_CAR_NAME)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
     rentACar = new RentACar(info, processor)
 
 		car = new Car(PLATE_CAR,10,10,rentACar)

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest.groovy
@@ -33,10 +33,7 @@ class RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest extends SpockRollb
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-    def info = new InfoStruct()
-    info.setName(NAME1)
-    info.setNif(NIF)
-    info.setIban(IBAN)
+    def info = new InfoStruct.Builder().setName(NAME1).setNif(NIF).setIban(IBAN).build()
     rentACar1 = new RentACar(info, processor)
 
 		bankInterface = new BankInterface()

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest.groovy
@@ -2,11 +2,7 @@ package pt.ulisboa.tecnico.softeng.car.services.local
 
 import org.joda.time.LocalDate
 
-import pt.ulisboa.tecnico.softeng.car.domain.Car
-import pt.ulisboa.tecnico.softeng.car.domain.Motorcycle
-import pt.ulisboa.tecnico.softeng.car.domain.Processor
-import pt.ulisboa.tecnico.softeng.car.domain.RentACar
-import pt.ulisboa.tecnico.softeng.car.domain.SpockRollbackTestAbstractClass
+import pt.ulisboa.tecnico.softeng.car.domain.*
 import pt.ulisboa.tecnico.softeng.car.services.remote.BankInterface
 import pt.ulisboa.tecnico.softeng.car.services.remote.TaxInterface
 
@@ -37,13 +33,19 @@ class RentACarInterfaceGetAllAvailableVehiclesMethodSpockTest extends SpockRollb
 		def taxInterface = new TaxInterface()
 		def processor = new Processor(bankInterface, taxInterface)
 
-		rentACar1 = new RentACar(NAME1,NIF,IBAN, processor)
+    def info = new InfoStruct()
+    info.setName(NAME1)
+    info.setNif(NIF)
+    info.setIban(IBAN)
+    rentACar1 = new RentACar(info, processor)
 
 		bankInterface = new BankInterface()
 		taxInterface = new TaxInterface()
 		processor = new Processor(bankInterface, taxInterface)
 
-		rentACar2 = new RentACar(NAME2,NIF + '1',IBAN, processor)
+    info.setName(NAME2)
+    info.setNif(NIF + "1")
+		rentACar2 = new RentACar(info, processor)
 	}
 
 	def 'only cars'() {

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetRentingDataMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetRentingDataMethodSpockTest.groovy
@@ -2,10 +2,7 @@ package pt.ulisboa.tecnico.softeng.car.services.local
 
 import org.joda.time.LocalDate
 
-import pt.ulisboa.tecnico.softeng.car.domain.Car
-import pt.ulisboa.tecnico.softeng.car.domain.Processor
-import pt.ulisboa.tecnico.softeng.car.domain.RentACar
-import pt.ulisboa.tecnico.softeng.car.domain.SpockRollbackTestAbstractClass
+import pt.ulisboa.tecnico.softeng.car.domain.*
 import pt.ulisboa.tecnico.softeng.car.exception.CarException
 import pt.ulisboa.tecnico.softeng.car.services.remote.BankInterface
 import pt.ulisboa.tecnico.softeng.car.services.remote.TaxInterface
@@ -32,7 +29,11 @@ class RentACarInterfaceGetRentingDataMethodSpockTest extends SpockRollbackTestAb
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        def rentACar1 = new RentACar(NAME1, NIF, IBAN, processor)
+        def info = new InfoStruct()
+        info.setName(NAME1)
+        info.setNif(NIF)
+        info.setIban(IBAN)
+        def rentACar1 = new RentACar(info, processor)
         car = new Car(PLATE_CAR1, 10, 10, rentACar1)
     }
 

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetRentingDataMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceGetRentingDataMethodSpockTest.groovy
@@ -29,10 +29,7 @@ class RentACarInterfaceGetRentingDataMethodSpockTest extends SpockRollbackTestAb
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        def info = new InfoStruct()
-        info.setName(NAME1)
-        info.setNif(NIF)
-        info.setIban(IBAN)
+        def info = new InfoStruct.Builder().setName(NAME1).setNif(NIF).setIban(IBAN).build()
         def rentACar1 = new RentACar(info, processor)
         car = new Car(PLATE_CAR1, 10, 10, rentACar1)
     }

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceRentMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceRentMethodSpockTest.groovy
@@ -30,7 +30,11 @@ class RentACarInterfaceRentMethodSpockTest extends SpockRollbackTestAbstractClas
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        rentACar = new RentACar(RENT_A_CAR_NAME, NIF, IBAN, processor)
+        def info = new InfoStruct()
+        info.setName(RENT_A_CAR_NAME)
+        info.setNif(NIF)
+        info.setIban(IBAN)
+        rentACar = new RentACar(info, processor)
     }
 
     def 'rent a car has car available'() {

--- a/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceRentMethodSpockTest.groovy
+++ b/car/src/test/groovy/pt/ulisboa/tecnico/softeng/car/services/local/RentACarInterfaceRentMethodSpockTest.groovy
@@ -30,10 +30,7 @@ class RentACarInterfaceRentMethodSpockTest extends SpockRollbackTestAbstractClas
         def taxInterface = new TaxInterface()
         def processor = new Processor(bankInterface, taxInterface)
 
-        def info = new InfoStruct()
-        info.setName(RENT_A_CAR_NAME)
-        info.setNif(NIF)
-        info.setIban(IBAN)
+        def info = new InfoStruct.Builder().setName(RENT_A_CAR_NAME).setNif(NIF).setIban(IBAN).build()
         rentACar = new RentACar(info, processor)
     }
 


### PR DESCRIPTION
### Description:
* After running BetterCodeHub on the master branch, I identified that we could apply the maintainability guideline: **Keep Unit Interfaces Small**;
  - Created **InfoStruct** Class, and then I tested the code;
  - Changed RentACar constructor to receive a **InfoStruct**, then i compiled the source code;
  - Refactored the _car_ module test suite, and lastly ran the tests successfully.

#### Comment:
* Looking forward to your feedback please.